### PR TITLE
Editorial: keep the shape of logo in mobile screen

### DIFF
--- a/main.jsx
+++ b/main.jsx
@@ -274,7 +274,7 @@ function Layout(props) {
 function Header() {
   return (
     <section class="flex items-center gap-6">
-      <a href="/">
+      <a class="flex-shrink-0" href="/">
         <img src="/static/logo.svg" alt="wintercg logo" class="w-24 h-24" />
       </a>
       <a href="/" class="block space-y-1">


### PR DESCRIPTION
The logo looks horizontally shrunk in mobile screen. This PR fixes it. 

Before
<img width="408" alt="スクリーンショット 2022-05-10 12 07 20" src="https://user-images.githubusercontent.com/613956/167534905-dbf99131-5455-4b4d-a382-f666c62e40f6.png">

After
<img width="408" alt="スクリーンショット 2022-05-10 12 07 38" src="https://user-images.githubusercontent.com/613956/167534927-d7c055df-93c2-4deb-abaf-ea236a6f4571.png">

