### PR TITLE
Clarify the scope of the community group

### DIFF
--- a/data/work.json
+++ b/data/work.json
@@ -24,8 +24,14 @@
   },
   {
     "name": "Fetch",
-    "description": "A fork of the WHATWG Fetch specification to make it more suitable for server-side JavaScript environments.",
+    "description": "A fork of the WHATWG Fetch to make the upstream specification more suitable for server-side JavaScript environments.",
     "specification": "https://fetch.spec.wintercg.org",
     "repo": "fetch"
+  },
+  {
+    "name": "Sockets API",
+    "description": "A proposal incubating an API for establishing TCP connections in non-browser JavaScript environments.",
+    "specification": "https://sockets-api.proposal.wintercg.org",
+    "repo": "proposal-sockets-api"
   }
 ]

--- a/main.jsx
+++ b/main.jsx
@@ -134,8 +134,9 @@ function Faq() {
           </p>
           <p>
             We want to coordinate and propose updates to existing Web Platform
-            APIs (in existing venues) that we think would benefit the goal of a
-            comprehensive unified API surface for all JS developers.
+            APIs (in existing venues) and incubate new ideas that we think
+            would benefit the goal of a comprehensive unified API surface for
+            all JS developers.
           </p>
         </div>
         <div class="space-y-4">
@@ -174,12 +175,12 @@ function Faq() {
             <h2 class="text-2xl font-medium">What are we NOT trying to do?</h2>
           </a>
           <p>
-            We are not trying to be a specification body that specifies new
-            APIs. We want to work with members of existing specification bodies
-            to improve existing APIs.
+            We are not trying to be a specification body. We want to work with
+            members of existing specification bodies to improve existing APIs
+            and incubate new ideas that could one day become standards.
           </p>
           <p>
-            We will never fork or create new versions of existing
+            We will never publish a fork or new versions of existing
             specifications. For any change we propose, the goal is always for it
             to be incorporated into an upstream spec in an existing venue (such
             as WHATWG or W3C).


### PR DESCRIPTION
Socket API is a new API being incubated in the community group. Although it would not be published as a WinterCG "standard", it is being specified in the group. Clarify that the community group is not going to publish any standards but to incubate new ideas.

Refs: https://github.com/wintercg/admin/issues/56
